### PR TITLE
Bugfix: Variables RHS and Untyped Const Nodes

### DIFF
--- a/C_Compiler/header/ast.h
+++ b/C_Compiler/header/ast.h
@@ -42,7 +42,7 @@ ASTNode *create_program_ast(int num_lines);
 
 ASTNode *create_datatype_ast(int *datatype);
 
-ASTNode *create_const_ast(void *data);
+ASTNode *create_const_ast(int *datatype, void *data);
 
 ASTNode *create_id_ast(const char *id);
 

--- a/C_Compiler/header/compiler.h
+++ b/C_Compiler/header/compiler.h
@@ -51,6 +51,6 @@ void compile_return(Linked_List *instructions, ASTNode *return_node);
 void compile_rhs(Linked_List *instructions, ASTNode *rhs, int depth);
 void compile_operator(Linked_List *instructions, ASTNode *arithop);
 void compile_const(Linked_List *instructions, ASTNode *const_node);
-void compile_global_var(Linked_List *instructions, ASTNode *var_node);
+void compile_var(Linked_List *instructions, ASTNode *var_node, int depth);
 
 #endif // COMPILER_H

--- a/C_Compiler/header/parser.h
+++ b/C_Compiler/header/parser.h
@@ -24,6 +24,7 @@ ASTNode *parse_parameter_list();
 ASTNode *parse_rhs(Statement *statement, int rhs_index);
 ASTNode *shift_op(ASTNode *rhs);
 int is_const(Token token);
+int *determine_const_type(int type);
 ASTNode *append_to_leftmost(ASTNode *lhs, ASTNode *rhs);
 
 #endif // PARSER_H

--- a/C_Compiler/header/semantic.h
+++ b/C_Compiler/header/semantic.h
@@ -15,6 +15,6 @@ int analyze_assignment(ASTNode *assign, int depth);
 int analyze_if(ASTNode *if_node, int depth);
 int analyze_func_decl(ASTNode *func_decl);
 int analyze_return(ASTNode *return_node);
-int analyze_rhs(ASTNode *rhs, int datatype);
+int analyze_rhs(ASTNode *rhs, int datatype, int depth);
 
 #endif // SEMANTIC_H

--- a/C_Compiler/header/token.h
+++ b/C_Compiler/header/token.h
@@ -61,4 +61,6 @@ int is_subtype(Token token, int subtype);
 
 void *create_data_packet(Token token);
 
+char identify_char_literal(Token char_token);
+
 #endif // TOKEN_H

--- a/C_Compiler/src/ast.c
+++ b/C_Compiler/src/ast.c
@@ -19,11 +19,13 @@ ASTNode *create_datatype_ast(int *datatype) {
 	return node;
 }
 
-ASTNode *create_const_ast(void *data) {
+ASTNode *create_const_ast(int *datatype, void *data) {
 	ASTNode *node = malloc(sizeof(ASTNode));
 	node->type = CONST_NODE;
 	node->data = data;
-	node->num_sub = 0;
+	node->sub_nodes = malloc(sizeof(ASTNode));
+	SUB_NODE(node, 0) = create_datatype_ast(datatype);
+	node->num_sub = 1;
 	return node;
 }
 

--- a/C_Compiler/src/compiler.c
+++ b/C_Compiler/src/compiler.c
@@ -121,10 +121,7 @@ void compile_rhs(Linked_List *instructions, ASTNode *rhs, int depth) {
 		compile_operator(instructions, rhs);
 		break;
 	case VAR_NODE:
-		if (depth == 0) compile_global_var(instructions, rhs);
-		else {
-			// TODO
-		}
+		compile_var(instructions, rhs, depth);
 		break;
 	}
 }
@@ -152,7 +149,17 @@ void compile_const(Linked_List *instructions, ASTNode *const_node) {
 	add_link(instructions, GET_CONST_INT(const_node));
 }
 
-void compile_global_var(Linked_List *instructions, ASTNode *var_node) {
-	add_link(instructions, GLOAD_OP);	
-	add_link(instructions, get_global_addr(GET_AST_STR_DATA(SUB_NODE(var_node, 0)))->addr);
+void compile_var(Linked_List *instructions, ASTNode *var_node, int depth) {
+	char *id = GET_AST_STR_DATA(SUB_NODE(var_node, 0));
+	Memory_Address *addr = 0;
+	while (!addr && depth > 0) {
+		addr = get_local_addr(id, depth--);
+	}
+	if (!addr) {
+		add_link(instructions, GLOAD_OP);	
+		addr = get_global_addr(id);
+	} else {
+		add_link(instructions, LOAD_OP);
+	}
+	add_link(instructions, addr->addr);
 }

--- a/C_Compiler/src/parser.c
+++ b/C_Compiler/src/parser.c
@@ -49,7 +49,7 @@ ASTNode *parse_declaration(Statement *statement) {
 		if (is_type(tokens[2], ASSIGNMENT)) {
 			rhs = parse_rhs(statement, 3);
 		}
-		else if (is_type(tokens[2], EOS)) rhs = create_const_ast((void*) &zero);
+		else if (is_type(tokens[2], EOS)) rhs = create_const_ast(&zero, (void*) &zero);
 		else return 0;
 		return create_decl_ast(&GET_DATATYPE(statement), GET_DECL_ID(statement), rhs, statement->depth);
 	}
@@ -145,7 +145,9 @@ ASTNode *parse_rhs(Statement *statement, int rhs_index) {
 			throw_error(UNEXPECTED_TOKEN, "Unknown", lineno, str_add("Unexpected token ", tokens[statement_index + 1].token_str));	
 		}
 
-		ASTNode *lhs = create_const_ast(create_data_packet(tokens[rhs_index]));
+		int *const_type = determine_const_type(tokens[rhs_index].type);
+
+		ASTNode *lhs = create_const_ast(const_type, create_data_packet(tokens[rhs_index]));
 		if (!is_type(tokens[rhs_index + 1], EOS)) {
 			ASTNode *op = parse_rhs(statement, rhs_index + 1);
 			if (op) {
@@ -206,7 +208,15 @@ ASTNode *shift_op(ASTNode *rhs) {
 }
 
 int is_const(Token token) {
-	return is_type(token, NUM) || is_type(token, BOOLVAL);
+	return is_type(token, NUM) || is_type(token, BOOLVAL) || is_type(token, CHAR_LITERAL);
+}
+
+int *determine_const_type(int type) {
+	int *const_type = malloc(sizeof(int));
+	if (type == NUM) *const_type = INT;
+	if (type == BOOLVAL) *const_type = BOOL;
+	if (type == CHAR_LITERAL) *const_type = CHAR;
+	return const_type;
 }
 
 ASTNode *append_to_leftmost(ASTNode *lhs, ASTNode *rhs) {

--- a/C_Compiler/src/semantic.c
+++ b/C_Compiler/src/semantic.c
@@ -151,8 +151,7 @@ int analyze_rhs(ASTNode *rhs, int datatype, int depth) {
 				throw_error(UNKNOWN_REFERENCE, "Unknown", lineno, "");
 				return 0;
 			}
-			if (var->type == datatype) sp--;
-			else return 0;
+			sp--;
 			break;
 		}
 		}

--- a/C_Compiler/src/semantic.c
+++ b/C_Compiler/src/semantic.c
@@ -143,8 +143,8 @@ int analyze_rhs(ASTNode *rhs, int datatype, int depth) {
 			Memory_Address *var = 0;
 			char *id = GET_AST_STR_DATA(SUB_NODE(cur_node, 0));
 			int search_depth = depth;
-			while (!var && depth > 0) {
-				var = get_local_addr(id, depth--);
+			while (!var && search_depth > 0) {
+				var = get_local_addr(id, search_depth--);
 			}
 			if (!var) var = get_global_addr(id);
 			if (!var) {

--- a/C_Compiler/src/semantic.c
+++ b/C_Compiler/src/semantic.c
@@ -42,7 +42,7 @@ int analyze_decl(ASTNode *decl, int depth) {
 			Memory_Address *addr = create_mem_addr(1, NUM_GLOBAL, GET_AST_DATATYPE(decl));
 			int status = create_global_variable(id, addr);
 			ASTNode *rhs = SUB_NODE(decl, 2);
-			status = status && analyze_rhs(rhs, GET_AST_DATATYPE(decl));
+			status = status && analyze_rhs(rhs, GET_AST_DATATYPE(decl), depth);
 			if (status) return 1;
 		}	
 	} else if (depth == -1) { // FUNCTION ARGS}
@@ -60,7 +60,7 @@ int analyze_decl(ASTNode *decl, int depth) {
 			Memory_Address *addr = create_mem_addr(1, NUM_LOCAL + 1, GET_AST_DATATYPE(decl));
 			int status = create_local_variable(id, addr, depth);
 			ASTNode *rhs = SUB_NODE(decl, 2);
-			status = status && analyze_rhs(rhs, GET_AST_DATATYPE(decl));
+			status = status && analyze_rhs(rhs, GET_AST_DATATYPE(decl), depth);
 			if (status) return 1;
 		}
 	}
@@ -75,7 +75,7 @@ int analyze_assignment(ASTNode *assign, int depth) {
 		} else {
 			ASTNode *rhs = SUB_NODE(assign, 1);
 			int status = 0;
-			if (rhs) status = analyze_rhs(SUB_NODE(assign, 1), get_global_addr(id)->type);
+			if (rhs) status = analyze_rhs(SUB_NODE(assign, 1), get_global_addr(id)->type, depth);
 			if (status) return 1;
 		}
 	} else {
@@ -86,7 +86,7 @@ int analyze_assignment(ASTNode *assign, int depth) {
 			int status = 0;
 			Memory_Address *addr = get_local_addr(id, depth);
 			if (!addr) addr = get_global_addr(id);
-			if (rhs) status = analyze_rhs(SUB_NODE(assign, 1), addr->type);
+			if (rhs) status = analyze_rhs(SUB_NODE(assign, 1), addr->type, depth);
 			if (status) return 1;
 		}
 	}
@@ -94,7 +94,7 @@ int analyze_assignment(ASTNode *assign, int depth) {
 }
 
 int analyze_if(ASTNode *if_node, int depth) {
-	return analyze_rhs(SUB_NODE(if_node, 0), 2); // 2 is BOOL
+	return analyze_rhs(SUB_NODE(if_node, 0), 2, depth); // 2 is BOOL
 }
 
 int analyze_func_decl(ASTNode *func_decl) {
@@ -116,14 +116,14 @@ int analyze_func_decl(ASTNode *func_decl) {
 
 int analyze_return(ASTNode *return_node) {
 	if (SUB_NODE(return_node, 1)) {
-		return analyze_rhs(SUB_NODE(return_node, 1), GET_AST_DATATYPE(return_node));
+		return analyze_rhs(SUB_NODE(return_node, 1), GET_AST_DATATYPE(return_node), return_node->depth);
 	} else if (GET_AST_DATATYPE(return_node) == 0) {
 		return 1;
 	}
 	return 0;
 }
 
-int analyze_rhs(ASTNode *rhs, int datatype) {
+int analyze_rhs(ASTNode *rhs, int datatype, int depth) {
 	int sp = 0;
 	ASTNode **stack = malloc(sizeof(rhs) * 255);
 	stack[sp++] = rhs;
@@ -139,10 +139,16 @@ int analyze_rhs(ASTNode *rhs, int datatype) {
 			stack[sp++] = SUB_NODE(cur_node, 1);
 			stack[sp++] = SUB_NODE(cur_node, 0);
 			break;
-		case VAR_NODE: {
-			Memory_Address *var = get_global_addr(GET_AST_STR_DATA(SUB_NODE(cur_node, 0)));
+		case VAR_NODE: {	
+			Memory_Address *var = 0;
+			char *id = GET_AST_STR_DATA(SUB_NODE(cur_node, 0));
+			int search_depth = depth;
+			while (!var && depth > 0) {
+				var = get_local_addr(id, depth--);
+			}
+			if (!var) var = get_global_addr(id);
 			if (!var) {
-				printf("Variable \"%s\" has not been declared.\n", GET_AST_STR_DATA(SUB_NODE(cur_node, 0)));
+				throw_error(UNKNOWN_REFERENCE, "Unknown", lineno, "");
 				return 0;
 			}
 			if (var->type == datatype) sp--;

--- a/C_Compiler/src/statement.c
+++ b/C_Compiler/src/statement.c
@@ -41,16 +41,27 @@ void tokenize_statement(Statement *statement) {
 
 	for (int i = 0; i < strlen(s) + 1; i++) {
 		if (s[i] == '\'') {
-			if (isalpha(s[i + 1]) && s[i + 2] == '\'') {
-				buffer[0] = s[i];
-				buffer[1] = s[i + 1];
-				buffer[2] = s[i + 2];	
-				buffer[3] = '\0';
+			bi = 0;
+			buffer[bi++] = s[i];
+			if (s[i + 1] == '\\' && s[i + 3] == '\'') {
+				buffer[bi++] = s[i + 1];
+				buffer[bi++] = s[i + 2];	
+				buffer[bi++] = s[i + 3];	
+				buffer[bi++] = '\0';
+				bi = 0;
+				add_token(statement, buffer);
+				i += 3;
+			} else if (s[i + 2] == '\'') {
+				buffer[bi++] = s[i + 1];
+				buffer[bi++] = s[i + 2];	
+				buffer[bi++] = '\0';
 				bi = 0;
 				add_token(statement, buffer);
 				i += 2;
-				continue;
+			} else {
+				// TODO: Throw invalid char literal error
 			}
+			continue;
 		}
 		if (s[i] == '\"') {
 			if (mode == 3) {

--- a/C_Compiler/src/tests.c
+++ b/C_Compiler/src/tests.c
@@ -247,9 +247,10 @@ int test_rhs() {
 }
 
 int test_ast() {
+	int type = 1;
 	int a = 1;
 	int b = 20;
-	ASTNode *rhs = create_const_ast(&b);
+	ASTNode *rhs = create_const_ast(&type, &b);
 	ASTNode *node = create_decl_ast(&a, "test", rhs, 0);
 	if (NODE_TYPE(SUB_NODE(node, 0)) != DATATYPE_NODE) return FAILURE;
 	if (!str_equal(GET_AST_DECL_ID(node), "test")) return FAILURE;

--- a/C_Compiler/src/token.c
+++ b/C_Compiler/src/token.c
@@ -40,7 +40,7 @@ void identify_token_type(Token *token) {
 		token->type = PAREN;
 		token->subtype = list_index;
 		return;
-	} else if (s[0] == '\'' && isalnum(s[1]) && s[2] == '\'') {
+	} else if (s[0] == '\'') {
 		token->type = CHAR_LITERAL;
 		return;
 	} else if (s[0] == '\"') {
@@ -93,6 +93,51 @@ void *create_data_packet(Token token) {
 		int *bool_val = malloc(sizeof(int));
 		*bool_val = token.subtype;
 		return (void*) bool_val;
+	} else if (is_type(token, CHAR_LITERAL)) {
+		int *char_val = malloc(sizeof(int));
+		*char_val = (int) identify_char_literal(token);
+		printf("%c\n", identify_char_literal(token));
+		return (void*) char_val;
 	}
 	return 0;
+}
+
+char identify_char_literal(Token char_token) {
+	const char *char_str = char_token.token_str;
+	char character = 0;
+	printf("Identifying: %s\n", char_str);
+	if (char_str[1] == '\\') {
+		switch (char_str[2]) {
+		case '\'':
+			character = '\'';
+			break;
+		case '\"':
+			character = '\"';
+			break;
+		case '\\':
+			character = '\\';
+			break;
+		case 'n':
+			character = '\n';
+			break;
+		case 'r':
+			character = '\r';
+			break;
+		case 't':
+			character = '\t';
+			break;
+		case 'b':
+			character = '\b';
+			break;
+		case 'f':
+			character = '\f';
+			break;
+		case '0':
+			character = '\0';
+			break;
+		}
+	} else {
+		character = char_str[1];
+	}
+	return character;
 }


### PR DESCRIPTION
#Summary
Adds a datatype subnode to `CONST_NODE` for the purpose of further right hand side checking of valid datatypes.
This code also allows for the correct compilation of local and global variables in right hand side statements. 

Fixes #3 
Fixes #4