### PR TITLE
Bugfix: RHS Type Checking

### DIFF
--- a/C_Compiler/header/ast.h
+++ b/C_Compiler/header/ast.h
@@ -13,7 +13,6 @@
 #define GET_AST_DATATYPE(ast) *(int*) ast->sub_nodes[0]->data
 
 typedef struct ASTNode ASTNode;
-
 typedef enum {
 	PROG_NODE,
 	DECL_NODE,

--- a/C_Compiler/header/error.h
+++ b/C_Compiler/header/error.h
@@ -4,13 +4,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define NUM_ERROR_TYPES 4
+#define NUM_ERROR_TYPES 6
 
 typedef enum {
 	UNKNOWN_REFERENCE,
 	VARIABLE_EXISTS,
 	FUNCTION_EXISTS,
-	UNEXPECTED_TOKEN
+	UNEXPECTED_TOKEN,
+	TYPE_MISMATCH,
+	INVALID_OPERANDS
 } Error_Type;
 
 const char *ErrorNames[NUM_ERROR_TYPES];

--- a/C_Compiler/header/semantic.h
+++ b/C_Compiler/header/semantic.h
@@ -5,6 +5,7 @@
 #include "memory.h"
 #include "shared_values.h"
 #include "error.h"
+#include "token.h"
 
 int lineno;
 int prev_depth;
@@ -16,5 +17,7 @@ int analyze_if(ASTNode *if_node, int depth);
 int analyze_func_decl(ASTNode *func_decl);
 int analyze_return(ASTNode *return_node);
 int analyze_rhs(ASTNode *rhs, int datatype, int depth);
+
+int determine_resulting_datatype(ASTNode *op_node);
 
 #endif // SEMANTIC_H

--- a/C_Compiler/header/semantic.h
+++ b/C_Compiler/header/semantic.h
@@ -19,5 +19,6 @@ int analyze_return(ASTNode *return_node);
 int analyze_rhs(ASTNode *rhs, int datatype, int depth);
 
 int determine_resulting_datatype(ASTNode *op_node);
+int check_datatype(ASTNode *node, int datatype);
 
 #endif // SEMANTIC_H

--- a/C_Compiler/res/compile_test.in
+++ b/C_Compiler/res/compile_test.in
@@ -1,3 +1,6 @@
-int add(int a, int b)
-	return 1
-int c
+int a = 3 * 4 / 5
+
+if (a == 5)
+	int c
+
+int b = 5

--- a/C_Compiler/res/semantic_test.in
+++ b/C_Compiler/res/semantic_test.in
@@ -1,3 +1,9 @@
-int a
+int a = 3
+
+if (a == 3)
+	int c = 3
+	int d = c
+	a = d
+
 void b(int a)
 	return

--- a/C_Compiler/src/ast.c
+++ b/C_Compiler/src/ast.c
@@ -112,15 +112,16 @@ ASTNode *create_operator_ast(int *operation) {
 	SUB_NODE(node, 0) = NULL;
 	SUB_NODE(node, 1) = NULL;
 	SUB_NODE(node, 2) = NULL;
-	node->num_sub = 2;
+	node->num_sub = 3;
 	return node;
 }
 
 ASTNode *create_var_ast(const char *id) {
 	ASTNode *node = malloc(sizeof(ASTNode));
 	node->type = VAR_NODE;
-	node->sub_nodes = malloc(sizeof(ASTNode) * 1);
-	SUB_NODE(node, 0) = create_id_ast(id);
-	node->num_sub = 1;
+	node->sub_nodes = malloc(sizeof(ASTNode) * 2);
+	SUB_NODE(node, 0) = NULL;
+	SUB_NODE(node, 1) = create_id_ast(id);
+	node->num_sub = 2;
 	return node;
 }

--- a/C_Compiler/src/ast.c
+++ b/C_Compiler/src/ast.c
@@ -108,9 +108,10 @@ ASTNode *create_operator_ast(int *operation) {
 	ASTNode *node = malloc(sizeof(ASTNode));
 	node->type = OPERATOR_NODE;
 	node->data = (void*) operation;
-	node->sub_nodes = malloc(sizeof(ASTNode) * 2);
+	node->sub_nodes = malloc(sizeof(ASTNode) * 3);
 	SUB_NODE(node, 0) = NULL;
 	SUB_NODE(node, 1) = NULL;
+	SUB_NODE(node, 2) = NULL;
 	node->num_sub = 2;
 	return node;
 }

--- a/C_Compiler/src/compiler.c
+++ b/C_Compiler/src/compiler.c
@@ -116,8 +116,8 @@ void compile_rhs(Linked_List *instructions, ASTNode *rhs, int depth) {
 		compile_const(instructions, rhs);
 		break;
 	case OPERATOR_NODE:
-		compile_rhs(instructions, SUB_NODE(rhs, 0), depth);
 		compile_rhs(instructions, SUB_NODE(rhs, 1), depth);
+		compile_rhs(instructions, SUB_NODE(rhs, 2), depth);
 		compile_operator(instructions, rhs);
 		break;
 	case VAR_NODE:

--- a/C_Compiler/src/compiler.c
+++ b/C_Compiler/src/compiler.c
@@ -150,7 +150,7 @@ void compile_const(Linked_List *instructions, ASTNode *const_node) {
 }
 
 void compile_var(Linked_List *instructions, ASTNode *var_node, int depth) {
-	char *id = GET_AST_STR_DATA(SUB_NODE(var_node, 0));
+	char *id = GET_AST_STR_DATA(SUB_NODE(var_node, 1));
 	Memory_Address *addr = 0;
 	while (!addr && depth > 0) {
 		addr = get_local_addr(id, depth--);

--- a/C_Compiler/src/error.c
+++ b/C_Compiler/src/error.c
@@ -4,7 +4,9 @@ const char *ErrorNames[] = {
 	"Unknown Reference Exception",
 	"Variable Exists",
 	"Function Exists",
-	"Unexpected Token"
+	"Unexpected Token",
+	"Type Mismatch",
+	"Invalid Operands"
 };
 
 void throw_error(Error_Type type, const char *filename, int lineno, const char *additional) {

--- a/C_Compiler/src/parser.c
+++ b/C_Compiler/src/parser.c
@@ -161,9 +161,9 @@ ASTNode *parse_rhs(Statement *statement, int rhs_index) {
 		}
 
 		ASTNode *op = create_operator_ast(&tokens[rhs_index].subtype);
-		SUB_NODE(op, 1) = parse_rhs(statement, rhs_index + 1);
-		if (SUB_NODE(op, 1)) {
-			if (!is_type(tokens[rhs_index + 1], PAREN) && (NODE_TYPE(SUB_NODE(op, 1)) == OPERATOR_NODE && GET_OP_TYPE(SUB_NODE(op, 1)) < GET_OP_TYPE(op))) {
+		SUB_NODE(op, 2) = parse_rhs(statement, rhs_index + 1);
+		if (SUB_NODE(op, 2)) {
+			if (!is_type(tokens[rhs_index + 1], PAREN) && (NODE_TYPE(SUB_NODE(op, 2)) == OPERATOR_NODE && GET_OP_TYPE(SUB_NODE(op, 2)) < GET_OP_TYPE(op))) {
 				ASTNode *rhs = shift_op(op);
 				return rhs;
 			}
@@ -179,7 +179,7 @@ ASTNode *parse_rhs(Statement *statement, int rhs_index) {
 				ASTNode *op = parse_rhs(statement, statement_index + 1);
 
 				if (op) {
-					SUB_NODE(op, 0) = lhs;
+					SUB_NODE(op, 1) = lhs;
 					return op;
 				}
 				return lhs;
@@ -201,9 +201,9 @@ ASTNode *parse_rhs(Statement *statement, int rhs_index) {
 
 ASTNode *shift_op(ASTNode *rhs) {
 	ASTNode *p = rhs;
-	ASTNode *r = SUB_NODE(rhs, 1);
-	SUB_NODE(p, 1) = SUB_NODE(r, 0);
-	SUB_NODE(r, 0) = p;
+	ASTNode *r = SUB_NODE(rhs, 2);
+	SUB_NODE(p, 2) = SUB_NODE(r, 1);
+	SUB_NODE(r, 1) = p;
 	return r;
 }
 
@@ -221,7 +221,7 @@ int *determine_const_type(int type) {
 
 ASTNode *append_to_leftmost(ASTNode *lhs, ASTNode *rhs) {
 	ASTNode *leftmost = rhs;
-	while (SUB_NODE(leftmost, 0)) leftmost = SUB_NODE(leftmost, 0);
-	SUB_NODE(leftmost, 0) = lhs;
+	while (SUB_NODE(leftmost, 1)) leftmost = SUB_NODE(leftmost, 1);
+	SUB_NODE(leftmost, 1) = lhs;
 	return rhs;
 }

--- a/C_Compiler/src/tests.c
+++ b/C_Compiler/src/tests.c
@@ -239,10 +239,10 @@ int test_rhs() {
 	ASTNode *rhs = parse_rhs(statement, 3);
 	if (!rhs) return FAILURE;
 	if (NODE_TYPE(rhs) != OPERATOR_NODE || GET_OP_TYPE(rhs) != EQ) return FAILURE;
-	if (NODE_TYPE(SUB_NODE(rhs, 0)) != OPERATOR_NODE || GET_OP_TYPE(SUB_NODE(rhs, 0)) != MULTIPLY) return FAILURE;
-	if (NODE_TYPE(SUB_NODE(SUB_NODE(rhs, 0), 0)) != VAR_NODE) return FAILURE;
-	if (GET_CONST_INT(SUB_NODE(SUB_NODE(rhs, 0), 1)) != 300) return FAILURE;
-	if (GET_CONST_INT(SUB_NODE(rhs, 1)) != 200) return FAILURE;
+	if (NODE_TYPE(SUB_NODE(rhs, 1)) != OPERATOR_NODE || GET_OP_TYPE(SUB_NODE(rhs, 1)) != MULTIPLY) return FAILURE;
+	if (NODE_TYPE(SUB_NODE(SUB_NODE(rhs, 1), 1)) != VAR_NODE) return FAILURE;
+	if (GET_CONST_INT(SUB_NODE(SUB_NODE(rhs, 1), 2)) != 300) return FAILURE;
+	if (GET_CONST_INT(SUB_NODE(rhs, 2)) != 200) return FAILURE;
 	return SUCCESS;
 }
 

--- a/C_Compiler/src/token.c
+++ b/C_Compiler/src/token.c
@@ -96,7 +96,6 @@ void *create_data_packet(Token token) {
 	} else if (is_type(token, CHAR_LITERAL)) {
 		int *char_val = malloc(sizeof(int));
 		*char_val = (int) identify_char_literal(token);
-		printf("%c\n", identify_char_literal(token));
 		return (void*) char_val;
 	}
 	return 0;
@@ -105,7 +104,6 @@ void *create_data_packet(Token token) {
 char identify_char_literal(Token char_token) {
 	const char *char_str = char_token.token_str;
 	char character = 0;
-	printf("Identifying: %s\n", char_str);
 	if (char_str[1] == '\\') {
 		switch (char_str[2]) {
 		case '\'':


### PR DESCRIPTION
# Summary
The right hand side is now recursively checked for type consistency.
Operator and Var nodes now have a datatype AST attached for tagging. This allows for type checking.
Additional error codes were added for more verbose error messages.

Fixes #6 