### PR TITLE
Bugfix: EOF does not Exist Depth

### DIFF
--- a/C_Compiler/res/compile_test.in
+++ b/C_Compiler/res/compile_test.in
@@ -3,4 +3,3 @@ int i = 0
 while i < 10
 	i = i + 1
 	print i
-

--- a/C_Compiler/src/compiler.c
+++ b/C_Compiler/src/compiler.c
@@ -6,7 +6,7 @@ Linked_List *compile(ASTNode *program) {
 	Linked_List *instructions = create_linked_list();
 	pda_sp = 0;
 	prev_depth = 0;
-	for (int i = 0; i < num_lines; i++) {
+	for (int i = 0; i < num_lines + 1; i++) {
 		ASTNode *node = SUB_NODE(program, i);
 
 		if (pda_sp != 0) {

--- a/C_Compiler/src/parser.c
+++ b/C_Compiler/src/parser.c
@@ -1,7 +1,7 @@
 #include <parser.h>
 
 ASTNode *parse(Statement *statements) {
-	ASTNode *program = create_program_ast(num_lines);
+	ASTNode *program = create_program_ast(num_lines + 1);
 	in_function = 0;
 	for (int i = 0; i < num_lines; i++) {
 		lineno = i + 1;
@@ -14,6 +14,10 @@ ASTNode *parse(Statement *statements) {
 			printf("Line %i is not a statement.\n", i + 1);
 		}
 	}
+	ASTNode *node = malloc(sizeof(ASTNode));
+	node->type = BLANK_NODE;
+	node->depth = 0;
+	SUB_NODE(program, num_lines) = node;
 	return program;
 }
 
@@ -132,8 +136,7 @@ ASTNode *parse_func_call(Statement *statement, int index) {
 					// TODO: throw_error();
 				}
 			} else {
-				int paren_count = 1;
-				for (int i = statement_index; paren_count > 0; i++) {
+				int paren_count = 1; for (int i = statement_index; paren_count > 0; i++) {
 					if (is_type(tokens[i], PAREN)) {
 						if (is_subtype(tokens[i], LPAREN)) {
 							paren_count++;

--- a/C_Compiler/src/semantic.c
+++ b/C_Compiler/src/semantic.c
@@ -5,7 +5,7 @@ int semantic_analysis(ASTNode *prog) {
 	int status = 1;
 	lineno = 0;
 	prev_depth = 0;
-	for (int i = 0; i < num_lines; i++) {
+	for (int i = 0; i < num_lines + 1; i++) {
 		lineno = i + 1;
 		ASTNode *node = SUB_NODE(prog, i);
 		if (node->depth < prev_depth) {


### PR DESCRIPTION
# Summary
This merge fixes the problem where the EOF does not count as an exit to depth 0 and does not trigger `PDA`s. This resulted in invalid bytecode. This is now rectified by inserting a false `BLANK_NODE` at the end of the file.

Fixes #17 