### PR TITLE
Bugfix: Arbitrary Depth Access

### DIFF
--- a/C_Compiler/header/error.h
+++ b/C_Compiler/header/error.h
@@ -4,8 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define NUM_ERROR_TYPES 7
-
 typedef enum {
 	UNKNOWN_REFERENCE,
 	VARIABLE_EXISTS,
@@ -13,7 +11,10 @@ typedef enum {
 	UNEXPECTED_TOKEN,
 	TYPE_MISMATCH,
 	INVALID_OPERANDS,
-	INSUFFICIENT_ARGS
+	INSUFFICIENT_ARGS,
+	MAXIMUM_DEPTH_EXCEEDED,
+	INACTIVE_DEPTH,
+	NUM_ERROR_TYPES
 } Error_Type;
 
 const char *ErrorNames[NUM_ERROR_TYPES];

--- a/C_Compiler/header/memory.h
+++ b/C_Compiler/header/memory.h
@@ -8,8 +8,10 @@
 
 #define NUM_GLOBAL global_memory->num_values
 #define NUM_FUNC function_addresses->num_values
+#define MAX_DEPTH 255
 
-Map *global_memory, *local_memory[255], *function_addresses, *datatypes;
+Map *global_memory, *local_memory[MAX_DEPTH], *function_addresses, *datatypes;
+int last_active_depth;
 
 int NUM_LOCAL;
 
@@ -37,7 +39,9 @@ int create_global_variable(const char *key, Memory_Address *addr);
 int create_local_variable(const char *key, Memory_Address *addr, int depth);
 int add_function(const char *key, Function *function);
 
+int descend_depth();
 void exit_depth(int depth);
+int is_depth_active(int depth);
 
 Memory_Address *get_global_addr(const char *key);
 Memory_Address *get_local_addr(const char *key, int depth);

--- a/C_Compiler/src/error.c
+++ b/C_Compiler/src/error.c
@@ -7,7 +7,9 @@ const char *ErrorNames[] = {
 	"Unexpected Token",
 	"Type Mismatch",
 	"Invalid Operands",
-	"Insufficient Arguments"
+	"Insufficient Arguments",
+	"Maximum Statement Depth Exceeded",
+	"Inactive Depth"
 };
 
 void throw_error(Error_Type type, const char *filename, int lineno, const char *additional) {

--- a/C_Compiler/src/memory.c
+++ b/C_Compiler/src/memory.c
@@ -6,6 +6,7 @@ void init_mem() {
 		local_memory[i] = create_map();
 	function_addresses = create_map();
 	NUM_LOCAL = 0;
+	last_active_depth = 0;
 }
 
 void deinit_mem() {
@@ -25,6 +26,7 @@ void clear_mem() {
 		local_memory[i]->num_values = 0;
 	}
 	NUM_LOCAL = 0;
+	last_active_depth = 0;
 	rbt_destroy(function_addresses->root);
 	function_addresses->root = 0;
 	function_addresses->num_values = 0;
@@ -64,11 +66,24 @@ int add_function(const char *key, Function *func) {
 	return rbt_insert(function_addresses, key, func);
 }
 
+int descend_depth() {
+	last_active_depth++;
+	if (last_active_depth >= MAX_DEPTH) {
+		return 0;
+	}
+	return 1;
+}
+
 void exit_depth(int depth) {
+	last_active_depth--;
 	NUM_LOCAL -= local_memory[depth - 1]->num_values;
 	rbt_destroy(local_memory[depth - 1]->root);
 	local_memory[depth - 1]->root = 0;
 	local_memory[depth - 1]->num_values = 0;
+}
+
+int is_depth_active(int depth) {
+	return depth <= last_active_depth;
 }
 
 Memory_Address *get_global_addr(const char *key) {

--- a/C_Compiler/src/semantic.c
+++ b/C_Compiler/src/semantic.c
@@ -12,6 +12,11 @@ int semantic_analysis(ASTNode *prog) {
 		if (NODE_TYPE(node) == BLANK_NODE) {
 			continue; // Skip blank nodes
 		}
+		if (!is_depth_active(node->depth)) {
+			char *error_add;
+			sprintf(error_add, "Depth %d is currently inactive.", node->depth);
+			throw_error(INACTIVE_DEPTH, "Unknown", lineno, error_add);
+		}
 		if (node->depth < prev_depth) {
 			exit_depth(prev_depth); 
 		} 
@@ -24,12 +29,15 @@ int semantic_analysis(ASTNode *prog) {
 			break;
 		case IF_NODE:
 			status = status && analyze_if(node, node->depth);
+			descend_depth();
 			break;
 		case WHILE_NODE:
 			status = status && analyze_while(node, node->depth);
+			descend_depth();
 			break;
 		case FUNC_NODE:
 			status = status && analyze_func_decl(node);
+			descend_depth();
 			break;
 		case RETURN_NODE:
 			status = status && analyze_return(node);


### PR DESCRIPTION
# Summary
This merge contains code that prevents depths from being accessed prior to becoming "active". Depths are activated once, and only once, a statement capable of descending a depth has appeared.